### PR TITLE
Lower pr review policy confidence to enforce GithubCodeReview

### DIFF
--- a/checks/code_review.go
+++ b/checks/code_review.go
@@ -67,9 +67,10 @@ func IsPrReviewRequired(c checker.Checker) checker.CheckResult {
 		return checker.InconclusiveResult
 	}
 	if bp.GetRequiredPullRequestReviews().RequiredApprovingReviewCount >= 1 {
+		c.Logf("pr review policy enforced")
 		return checker.CheckResult{
 			Pass:       true,
-			Confidence: 10,
+			Confidence: 5,
 		}
 	}
 	return checker.InconclusiveResult
@@ -102,7 +103,6 @@ func ProwCodeReview(c checker.Checker) checker.CheckResult {
 	if totalReviewed == 0 {
 		return checker.InconclusiveResult
 	}
-
 	c.Logf("prow code reviews found")
 
 	return checker.ProportionalResult(totalReviewed, totalMerged, .75)


### PR DESCRIPTION
PR review policy is good to check but keep its confidence low
since actual enforcement is checked by GithubCodeReview and
ProwCodeReview and those values should be used.